### PR TITLE
fix: remove trailing newline from link render template

### DIFF
--- a/themes/cjbackman/layouts/_default/_markup/render-link.html
+++ b/themes/cjbackman/layouts/_default/_markup/render-link.html
@@ -1,4 +1,4 @@
 <a href="{{ .Destination | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}
   {{- if or (strings.HasPrefix .Destination "http") (strings.HasPrefix .Destination "//") }} target="_blank" rel="noopener noreferrer"{{ end }}>
   {{- .Text | safeHTML -}}
-</a>
+</a>{{- "" -}}


### PR DESCRIPTION
The trailing newline after </a> was emitted as a space in HTML inline
content, causing a visible gap between links and adjacent punctuation.

https://claude.ai/code/session_01HZv5grvH43zGAGCQdD63oG